### PR TITLE
Add support for Multiprocess (multi-host/multi-node) T5x runs

### DIFF
--- a/t5x/train.py
+++ b/t5x/train.py
@@ -704,9 +704,8 @@ if __name__ == '__main__':
                  '`coordinator_address`, `num_processes` and `process_id` '
                  'variables!')
 
-      if FLAGS.coordinator_address == None or \
-          FLAGS.num_processes == None or \
-          FLAGS.process_id == None :
+      if (FLAGS.coordinator_address == None or FLAGS.num_processes == None or
+          FLAGS.process_id == None):
         raise ValueError(err_msg)
 
       logging.info(

--- a/t5x/train.py
+++ b/t5x/train.py
@@ -669,28 +669,24 @@ if __name__ == '__main__':
 
   # Following flags are needed for multiprocess runs
   flags.DEFINE_boolean(
-    'multiprocess',
-    False,
-    help='If set, enable multihost runs, initialize using `jax.distributed()`. '
-    'Care required to provide correct `coordinator_address`, `num_processes` '
-    'and `process_id` values as well.')
+      'multiprocess',
+      False,
+      help='If set, enable multihost runs, initialize using '
+      '`jax.distributed()`. Care required to provide correct '
+      '`coordinator_address`, `num_processes` and `process_id` '
+      'values as well.')
 
   flags.DEFINE_string(
-    'coordinator_address',
-    None,
-    help='The IP address and port using which all the processes can coordinate '
-    'for communication. e.g. `127.0.0.1:12345`')
+      'coordinator_address',
+      None,
+      help='The IP address and port using which all the processes can '
+      'coordinate for communication. e.g. `127.0.0.1:12345`.')
 
-  flags.DEFINE_integer(
-    'num_processes',
-    None,
-    help='Total num of processes in multi process runs.' )
+  flags.DEFINE_integer('num_processes',
+                       None,
+                       help='Total num of processes in multi process runs.')
 
-  flags.DEFINE_integer(
-    'process_id',
-    None,
-    help='Index of the current process.')
-
+  flags.DEFINE_integer('process_id', None, help='Index of the current process.')
 
   def main(argv: Sequence[str]):
     """Wrapper for pdb post mortems."""
@@ -704,21 +700,23 @@ if __name__ == '__main__':
     # check if all the required info is present for multiprocess runs
     if FLAGS.multiprocess:
 
-      logging.info('Coordinator address: %s, Total Processes: %d, '
-                    'Process ID: %d',
-                   FLAGS.coordinator_address, FLAGS.num_processes,
-                   FLAGS.process_id)
-
       err_msg = ('To properly use multiprocess, provide valid values for '
                  '`coordinator_address`, `num_processes` and `process_id` '
                  'variables!')
+
       if FLAGS.coordinator_address == None or \
           FLAGS.num_processes == None or \
           FLAGS.process_id == None :
         raise ValueError(err_msg)
 
+      logging.info(
+          'Coordinator address: %s, Total Processes: %d, '
+          'Process ID: %d', FLAGS.coordinator_address, FLAGS.num_processes,
+          FLAGS.process_id)
+
       # jax multiprocess initialize
-      jax.distributed.initialize(FLAGS.coordinator_address, FLAGS.num_processes, FLAGS.process_id)
+      jax.distributed.initialize(FLAGS.coordinator_address, FLAGS.num_processes,
+                                 FLAGS.process_id)
 
     if FLAGS.tfds_data_dir:
       seqio.set_tfds_data_dir_override(FLAGS.tfds_data_dir)

--- a/t5x/train.py
+++ b/t5x/train.py
@@ -700,13 +700,13 @@ if __name__ == '__main__':
     # check if all the required info is present for multiprocess runs
     if FLAGS.multiprocess:
 
-      err_msg = ('To properly use multiprocess, provide valid values for '
-                 '`coordinator_address`, `num_processes` and `process_id` '
-                 'variables!')
-
-      if (FLAGS.coordinator_address == None or FLAGS.num_processes == None or
+      if (FLAGS.coordinator_address == None or
+          FLAGS.num_processes == None or
           FLAGS.process_id == None):
-        raise ValueError(err_msg)
+        raise ValueError(
+            '`coordinator_address`, `num_processes` and `process_id` '
+            'should not be None. Please provide those values to initialize the '
+            'distributed system')
 
       logging.info(
           'Coordinator address: %s, Total Processes: %d, '

--- a/t5x/train.py
+++ b/t5x/train.py
@@ -679,7 +679,7 @@ if __name__ == '__main__':
     'coordinator_address',
     None,
     help='The IP address and port using which all the processes can coordinate '
-    'for communication.')
+    'for communication. e.g. `127.0.0.1:12345`')
 
   flags.DEFINE_integer(
     'num_processes',
@@ -703,13 +703,19 @@ if __name__ == '__main__':
 
     # check if all the required info is present for multiprocess runs
     if FLAGS.multiprocess:
-      err_msg = ('Provide values for `num_processes` and `process_id` variables')
-      assert FLAGS.coordinator_address != None and \
-             FLAGS.num_processes != None and \
-             FLAGS.process_id != None, err_msg
 
-      logging.info('Server address: %s, Total hosts: %d, Host ID: %d',
-                   FLAGS.coordinator_address, FLAGS.num_processes, FLAGS.process_id)
+      logging.info('Coordinator address: %s, Total Processes: %d, '
+                    'Process ID: %d',
+                   FLAGS.coordinator_address, FLAGS.num_processes,
+                   FLAGS.process_id)
+
+      err_msg = ('To properly use multiprocess, provide valid values for '
+                 '`coordinator_address`, `num_processes` and `process_id` '
+                 'variables!')
+      if FLAGS.coordinator_address == None or \
+          FLAGS.num_processes == None or \
+          FLAGS.process_id == None :
+        raise ValueError(err_msg)
 
       # jax multiprocess initialize
       jax.distributed.initialize(FLAGS.coordinator_address, FLAGS.num_processes, FLAGS.process_id)


### PR DESCRIPTION
To run T5x on multi-node and multi-GPUs, `jax.distributed.initialize`
needs to be called with appropriate setup as mentioned here:
https://github.com/google/jax/pull/8364.
Added a command line flag - `multiprocess` to enable multiprocess T5x run
on GPUs.  Also, added command line flags for the arguments to
`jax.distributed.initialize`, namely - `coordinator_address`,
`num_processes` and `process_id`.

Example usage 1 (2 processes, running on 2 separate nodes, 8 GPUs each):
On the first node:
```
python3 ${T5X_DIR}/t5x/train.py \
  --gin_file="t5x/examples/t5/t5_1_1/examples/base_wmt_from_scratch.gin" \
  --gin.MODEL_DIR=\"${MODEL_DIR}\" \
  --tfds_data_dir=${TFDS_DATA_DIR} \
  --multiprocess \
  --coordinator_address=i.p.ad.dr:port \
  --num_processes=2 \
  --process_id=0
```

On the second node:
```
python3 ${T5X_DIR}/t5x/train.py \
  --gin_file="t5x/examples/t5/t5_1_1/examples/base_wmt_from_scratch.gin" \
  --gin.MODEL_DIR=\"${MODEL_DIR}\" \
  --tfds_data_dir=${TFDS_DATA_DIR} \
  --multiprocess \
  --coordinator_address=i.p.ad.dr:port \
  --num_processes=2 \
  --process_id=1
```
Notice that the `process_id` is different for the two processes. Also,
substitute the appropriate coordinator_address in `i.p.ad.dr:port`

Example usage 2 (1 node, 2 processes, 4 GPUs each):
```
CUDA_VISIBLE_DEVICES=0,1,2,3 python3 ${T5X_DIR}/t5x/train.py \
  --gin_file="t5x/examples/t5/t5_1_1/examples/base_wmt_from_scratch.gin" \
  --gin.MODEL_DIR=\"${MODEL_DIR}\" \
  --tfds_data_dir=${TFDS_DATA_DIR} \
  --multiprocess \
  --coordinator_address=127.0.0.1:12345 \
  --num_processes=2 \
  --process_id=0 & \
  && CUDA_VISIBLE_DEVICES=4,5,6,7 python3 ${T5X_DIR}/t5x/train.py \
  --gin_file="t5x/examples/t5/t5_1_1/examples/base_wmt_from_scratch.gin" \
  --gin.MODEL_DIR=\"${MODEL_DIR}\" \
  --tfds_data_dir=${TFDS_DATA_DIR} \
  --multiprocess \
  --coordinator_address=127.0.0.1:12345 \
  --num_processes=2 \
  --process_id=1
```

More information about multiprocess JAX runs:
https://github.com/google/jax/issues/2731

Note: T5x partitioning fix: https://github.com/google-research/t5x/pull/608
complements this change.

Fixes #410/#89