### PR TITLE
NVIDIA: Fix Dockerfile JAX version issue from upstream merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ be read by TensorBoard.
 
 ## GPU Usage
 
-T5X can be run easily on GPUs either in single-node configurations or multi-node configurations with a SLURM+pyxis cluster. Further instructions at [t5x/contrib/gpu/scripts_gpu](./t5x/contrib/gpu/scripts_gpu/README.md). The `t5x/scripts_gpu` folder contains example scripts for pretraining T5X on [The Pile](https://pile.eleuther.ai/) and for finetuning on SQuAD and MNLI. These scripts and associated `gin` configurations also contain additional GPU optimizations for better throughput.
+T5X can be run easily on GPUs either in single-node configurations or multi-node configurations with a SLURM+pyxis cluster. Further instructions at [t5x/contrib/gpu/scripts_gpu](./t5x/contrib/gpu/scripts_gpu/README.md). The `t5x/contrib/gpu/scripts_gpu` folder contains example scripts for pretraining T5X on [The Pile](https://pile.eleuther.ai/) and for finetuning on SQuAD and MNLI. These scripts and associated `gin` configurations also contain additional GPU optimizations for better throughput.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ be read by TensorBoard.
 
 ## GPU Usage
 
-T5X can be run easily on GPUs either in single-node configurations or multi-node configurations with a SLURM+pyxis cluster. Further instructions at [t5x/scripts_gpu](./t5x/scripts_gpu/README.md). The `t5x/scripts_gpu` folder contains example scripts for pretraining T5X on [The Pile](https://pile.eleuther.ai/) and for finetuning on SQuAD and MNLI. These scripts and associated `gin` configurations also contain additional GPU optimizations for better throughput.
+T5X can be run easily on GPUs either in single-node configurations or multi-node configurations with a SLURM+pyxis cluster. Further instructions at [t5x/contrib/gpu/scripts_gpu](./t5x/contrib/gpu/scripts_gpu/README.md). The `t5x/scripts_gpu` folder contains example scripts for pretraining T5X on [The Pile](https://pile.eleuther.ai/) and for finetuning on SQuAD and MNLI. These scripts and associated `gin` configurations also contain additional GPU optimizations for better throughput.
 
 ## Installation
 

--- a/t5x/contrib/gpu/Dockerfile
+++ b/t5x/contrib/gpu/Dockerfile
@@ -2,7 +2,7 @@ ARG FROM_IMAGE_NAME=nvcr.io/nvidia/tensorflow:22.08-tf2-py3
 FROM ${FROM_IMAGE_NAME}
 
 # Install the latest jax
-RUN pip install jax[cuda]==0.3.23 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+RUN pip install jax[cuda]==0.4.1 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # setup directory paths for T5x
 ENV TFDS_DATA_DIR=/t5x_home/datasets/


### PR DESCRIPTION
@hwchung27 We had a small issue in the previous PR with the Dockerfile still having the old JAX version from before merging with upstream t5x. Fixed here.