### PR TITLE
[Fix JAX nightly CI] Add back t5 requirement for a specific script.

### DIFF
--- a/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config/setup.py
+++ b/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config/setup.py
@@ -22,4 +22,5 @@ setup(name='dummy_wikipedia_seqio',
       version='0.0.1',
       description='Dummy Wikipedia Seqio Task',
       author='The T5X Authors',
+      install_requires=['t5'],
      )


### PR DESCRIPTION
cdda31f4696068ec6b7ea58bc348db7b4cba3c33 remove t5 dependency, but this script still need it.

This should fix the JAX nightly CI that currently gives errors like:

```
ModuleNotFoundError: No module named 't5'
  In file "/localdir/e2e_tests_workspace/t5x/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config/small_pretrain_dummy_wikipedia.gin", line 26
    import t5.data.mixtures
```