### PR TITLE
Enable t5x on Intel XPU

### DIFF
--- a/t5x/partitioning.py
+++ b/t5x/partitioning.py
@@ -314,7 +314,7 @@ def default_mesh(num_partitions: int,
 
   if platform == 'cpu':
     return get_cpu_mesh()
-  elif platform == 'gpu':
+  elif platform == 'gpu' or platform == 'xpu':
     return get_gpu_mesh(num_partitions)
 
   mps = None


### PR DESCRIPTION
Hi, developers,
  I am from Intel XLA team. we are developing an XLA compiler with Intel GPU support, the compiler is based on PJRT C API interface, and JAX currently support plug in a new platform through PJRT C Client, so we currently can support JAX-based models. We also want to run t5x as it is a popular LLM framework, but we currently met an issue in partition, it hardcoded `cpu`, `gpu`, `tpu` platform name to create mesh topology for each platform, as you may know, , we have Intel's GPU support in Framework(Pytorch, TensorFlow, JAX) with device type as XPU, so we also want to leverage this platform name(XPU) in JAX ecosystem. 

