### PR TITLE
Update gpu instructions everywhere to use the gpu extra

### DIFF
--- a/docs/usage/gpu-usage.md
+++ b/docs/usage/gpu-usage.md
@@ -8,7 +8,10 @@ An updated version of T5x with optimized GPU performance (18-80% perf gains!) an
 
 The [t5x/contrib/gpu](../../t5x/contrib/gpu) directory contains scripts optimized for GPU usage.
 
-Install with `pip install -r pile_requirements.txt` to get all pile dependencies.
+To get all dependencies for the Pile dataset, install with the `gpu` extra:
+```bash
+pip install '.[gpu]'
+```
 
 ## Building the container
 The Dockerfile in `t5x/contrib/gpu` given will build a container with all gpu/pile dependencies. It can be built with `t5x/contrib/gpu/docker/build.sh <name>` 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,9 @@ setuptools.setup(
             'gdown==4.5.3',
             'best-download==0.0.9',
             'lm_dataformat==0.0.20',
+            'dllogger@git+https://github.com/NVIDIA/dllogger#egg=dllogger',
             'tfds-nightly==4.6.0.dev202210040045',
+            't5==0.9.4',
         ],
     },
     classifiers=[

--- a/t5x/contrib/gpu/Dockerfile
+++ b/t5x/contrib/gpu/Dockerfile
@@ -13,5 +13,4 @@ WORKDIR /t5x_home
 
 # install the requirements for T5x
 COPY . .
-RUN pip install -e .
-RUN pip install -r t5x/contrib/gpu/scripts_gpu/pile_requirements.txt
+RUN pip install -e '.[gpu]'

--- a/t5x/contrib/gpu/README.md
+++ b/t5x/contrib/gpu/README.md
@@ -8,7 +8,10 @@ An updated version of T5x with optimized GPU performance and new features, inclu
 
 The [t5x/contrib/gpu/scripts_gpu](scripts_gpu) directory contains scripts optimized for GPU usage.
 
-Install with `pip install -r pile_requirements.txt` to get all pile dependencies.
+To get all dependencies for the Pile dataset, install with the `gpu` extra:
+```bash
+pip install '.[gpu]'
+```
 
 ## Building the container
 The Dockerfile in `t5x/contrib/gpu` given will build a container with all gpu/pile dependencies. It can be built with `t5x/contrib/gpu/docker/build.sh <name>` 

--- a/t5x/contrib/gpu/scripts_gpu/pile_requirements.txt
+++ b/t5x/contrib/gpu/scripts_gpu/pile_requirements.txt
@@ -1,9 +1,0 @@
-ipdb==0.13.9
-fasttext==0.9.2
-pysimdjson==5.0.2
-pytablewriter==0.64.2
-gdown==4.5.3
-best-download==0.0.9 
-lm_dataformat==0.0.20
-dllogger@git+https://github.com/NVIDIA/dllogger#egg=dllogger
-tfds-nightly==4.6.0.dev202210040045


### PR DESCRIPTION
Centralizing the gpu installs to the gpu extras instead of a requirements.txt file