### PR TITLE
Add DALI support to t5x

### DIFF
--- a/t5x/train.py
+++ b/t5x/train.py
@@ -111,10 +111,13 @@ def train(
     ],
     inference_evaluator_cls: utils.EvaluatorConstructor = seqio.Evaluator,
     get_dataset_fn: utils.GetDatasetCallable = utils.get_dataset,
+    prepare_train_iter_fn: Optional[Callable] = utils.prepare_train_iter,
     concurrent_metrics: bool = True,
     actions: Optional[Mapping[str, Sequence[trainer_lib.BaseAction]]] = None,
     train_eval_get_dataset_fn: utils.GetEvalDatasetCallable = utils.get_training_eval_datasets,
+    prepare_eval_iter_fn: Optional[Callable] = None,
     run_eval_before_training: bool = False,
+    run_dali_eval: bool = False,
     train_state_initializer_cls: Type[
         utils.TrainStateInitializer
     ] = utils.TrainStateInitializer,
@@ -164,6 +167,8 @@ def train(
       evaluation, potentially with bound configuration args.
     get_dataset_fn: The callable use to get the train and train-eval datasets
       based on the DatasetConfig and shard information.
+    prepare_train_iter_fn: An optional function that prepares the training input
+      iterator. Defaults to `utils.prepare_train_iter`.
     concurrent_metrics: If True, allow metrics computation and logging to
       overlap with training. Will likely result in additional TPU memory usage.
     actions: A mapping of actions that runs after train, eval or infer_eval, to
@@ -174,8 +179,11 @@ def train(
     train_eval_get_dataset_fn: Optional callable use to get the train-eval
       datasets based on the DatasetConfig and shard information. If missing, it
       defaults to `utils.get_training_eval_datasets`.
+    prepare_eval_iter_fn: An optional function that prepares the eval input
+      iterators.
     run_eval_before_training: If True, calculate training eval and inference
       eval metrics before training begins.
+    run_dali_eval: Whether to run interleaved evaluation on a DALI dataset.
     train_state_initializer_cls: t5x.utils.TrainStateInitializer class for
       initializing partitioned TrainState from checkpoints or scratch.
     use_orbax: if True, uses Orbax for checkpointing. Experimental feature.
@@ -280,11 +288,13 @@ def train(
 
   train_iter = get_dataset_fn(train_dataset_cfg, ds_shard_id, num_ds_shards,
                               model.FEATURE_CONVERTER_CLS)
-  train_iter = utils.prepare_train_iter(
-      train_iter,
-      checkpoint_cfg=checkpoint_cfg,
-      partitioner=partitioner,
-      data_layout=data_layout)
+
+  if prepare_train_iter_fn:
+    train_iter = prepare_train_iter_fn(
+        train_iter,
+        checkpoint_cfg=checkpoint_cfg,
+        partitioner=partitioner,
+        data_layout=data_layout)
 
   input_shapes = jax.tree_map(lambda x: (data_layout.batch_size, *x.shape[1:]),
                               train_iter.element_spec)
@@ -295,6 +305,12 @@ def train(
     train_eval_datasets = train_eval_get_dataset_fn(
         train_eval_dataset_cfg, ds_shard_id, num_ds_shards, eval_steps,
         model.FEATURE_CONVERTER_CLS)  # type: Mapping[str, tf.data.Dataset]
+    if prepare_eval_iter_fn:
+      for k in train_eval_datasets:
+        train_eval_datasets[k] = prepare_eval_iter_fn(train_eval_datasets[k],
+                                                checkpoint_cfg=checkpoint_cfg,
+                                                partitioner=partitioner,
+                                                data_layout=data_layout)
     if not train_eval_datasets:
       logging.warning(
           'No train_eval datasets loaded from config `train_eval_dataset_cfg`: '
@@ -459,19 +475,36 @@ def train(
   def _run_training_eval(first_run: bool = False):
     if first_run:
       logging.info('Compiling training eval loop.')
-      trainer.compile_eval({  # pytype: disable=wrong-arg-types  # jax-ndarray
-          task: utils.get_zeros_batch_like_dataset(ds)
-          for task, ds in train_eval_datasets.items()
-      })
+      if run_dali_eval:
+        trainer.compile_eval_dali({
+            task: utils.get_zeros_batch_like_dataset(ds)
+            for task, ds in train_eval_datasets.items()},
+            jnp.ones((train_eval_dataset_cfg.batch_size,)).astype(jnp.bool_))
+      else:
+        trainer.compile_eval({  # pytype: disable=wrong-arg-types  # jax-ndarray
+            task: utils.get_zeros_batch_like_dataset(ds)
+            for task, ds in train_eval_datasets.items()
+        })
     logging.info('Computing training evaluation metrics.')
-    eval_batch_iters = {
-        task: ds.as_numpy_iterator()
-        for task, ds in train_eval_datasets.items()
-    }
-    eval_summaries = trainer.eval(eval_batch_iters)
-    trainer.stop_training = run_actions(trainer_lib.ActionMode.TRAIN_EVAL,  # pytype: disable=wrong-arg-types  # jax-ndarray
-                                        actions, trainer.train_state,
-                                        eval_summaries)
+    if run_dali_eval:
+      eval_batch_iters = {
+          task: ds
+          for task, ds in train_eval_datasets.items()
+      }
+      eval_summaries = trainer.eval_dali(eval_batch_iters,
+                                         train_eval_dataset_cfg.batch_size,
+                                         ds_shard_id,
+                                         num_ds_shards,
+                                         eval_steps)
+    else:
+      eval_batch_iters = {
+          task: ds.as_numpy_iterator()
+          for task, ds in train_eval_datasets.items()
+      }
+      eval_summaries = trainer.eval(eval_batch_iters)
+      trainer.stop_training = run_actions(trainer_lib.ActionMode.TRAIN_EVAL,  # pytype: disable=wrong-arg-types  # jax-ndarray
+                                          actions, trainer.train_state,
+                                          eval_summaries)
 
   def _run_inference_eval():
     """Run prediction based inference eval."""
@@ -496,6 +529,19 @@ def train(
     if train_eval_datasets:
       logging.info('Running training eval before training.')
       _run_training_eval(first_run=True)
+      if run_dali_eval:
+        ## reset eval dataset
+        train_eval_datasets = train_eval_get_dataset_fn(
+          train_eval_dataset_cfg, ds_shard_id, num_ds_shards, eval_steps,
+          model.FEATURE_CONVERTER_CLS)
+        if prepare_eval_iter_fn:
+          for k in train_eval_datasets:
+            train_eval_datasets[k] = prepare_eval_iter_fn(train_eval_datasets[k],
+                                                    checkpoint_cfg=checkpoint_cfg,
+                                                    partitioner=partitioner,
+                                                    data_layout=data_layout)
+
+
     if evaluator is not None:
       logging.info('Running inference eval before training.')
       _run_inference_eval()
@@ -718,6 +764,18 @@ def train(
       # Maybe less if final step < period.
       first_run = step_offset // eval_period <= 1
       _run_training_eval(first_run and not run_eval_before_training)
+      if run_dali_eval:
+        ## reset eval dataset
+        train_eval_datasets = train_eval_get_dataset_fn(
+          train_eval_dataset_cfg, ds_shard_id, num_ds_shards, eval_steps,
+          model.FEATURE_CONVERTER_CLS)
+        if prepare_eval_iter_fn:
+          for k in train_eval_datasets:
+            train_eval_datasets[k] = prepare_eval_iter_fn(train_eval_datasets[k],
+                                                    checkpoint_cfg=checkpoint_cfg,
+                                                    partitioner=partitioner,
+                                                    data_layout=data_layout)
+
 
     # Inference Evaluation (i.e., with decoding or scoring).
     if is_eval_epoch and evaluator is not None:

--- a/t5x/trainer.py
+++ b/t5x/trainer.py
@@ -34,6 +34,7 @@ import clu.metrics
 import clu.values
 from flax.core import FrozenDict
 import jax
+from jax.experimental import multihost_utils
 import jax.lax
 import jax.numpy as jnp
 import jax.random
@@ -588,6 +589,99 @@ class BaseTrainer(abc.ABC):
     # TODO(adarob): Return futures.
     return {k: v.result() for k, v in eval_summaries.items()}
 
+  def eval_dali(
+      self, batch_iters: Mapping[str,
+                                 Iterator[BatchType]],
+      batch_size: int,
+      shard_id: int,
+      num_shards: int,
+      eval_steps: Optional[int] = None) -> Mapping[str, Array]:
+    """For DALI datasets, runs evaluation loop over the iterator and prints summary."""
+
+    def _remove_padding_eval(all_evaluations, all_nonpaddings):
+      """Remove padded examples."""
+
+      for k in all_evaluations:
+        all_evaluations[k] = all_evaluations[k][all_nonpaddings]
+      return all_evaluations
+
+    eval_summaries = {}
+    train_state = self.train_state
+
+    for iter_name, ds in batch_iters.items():
+      logging.info("Evaluating: %s.", iter_name)
+      metrics = None
+      # Use a pre-compiled step function, if available.
+      eval_step_fn = self._compiled_eval_steps.get(iter_name,
+                                                   self._partitioned_eval_step)
+
+      mm = self.eval_metrics_managers[iter_name]
+      nonpaddings = []
+      metrics = {}
+      last_source = None
+      batches_per_shard = None
+
+      num_steps = 0
+      mm.start_duration_timer(block_on=train_state)
+
+      for batch in ds:
+        num_steps += 1
+
+        utils.multihost_assert_equal(
+            jnp.array(num_steps),
+            "Eval step mismatch across hosts. Check for empty dataset shard.")
+
+        batch_nonpadding = ds.is_nonpadding
+
+        if jax.process_count() > 1:
+          batch, batch_nonpadding = partitioning.host_local_array_to_global_array(
+              (batch, batch_nonpadding), self._partitioner.mesh,
+              self._partitioner.data_partition_spec)
+
+        metrics_update, batch_nonpadding = eval_step_fn(train_state, batch, batch_nonpadding)
+
+        metrics_update, batch_nonpadding = (
+            multihost_utils.global_array_to_host_local_array(
+                (metrics_update, batch_nonpadding), self._partitioner.mesh,
+                (jax.sharding.PartitionSpec(), jax.sharding.PartitionSpec())
+            )
+        )
+
+        for k in metrics_update:
+          if k in metrics:
+            metrics[k] = np.concatenate((metrics[k], metrics_update[k]))
+          else:
+            metrics[k] = np.array(metrics_update[k])
+
+        if len(nonpaddings) == 0:
+          nonpaddings = batch_nonpadding
+        else:
+          nonpaddings = np.concatenate([nonpaddings, batch_nonpadding], axis=None)
+
+        if batches_per_shard is None:
+           meta = ds._iterator.wrapped_pipeline.meta
+           batches_per_shard = meta['epoch_size_padded'] / len(batch_nonpadding)
+
+        utils.multihost_assert_equal(
+          jnp.array(-1),
+          "Eval step mismatch across hosts. Check for empty dataset shard.")
+
+        ## indicates that we have reached the end of eval
+        if (eval_steps and num_steps >= eval_steps) or (num_steps >= batches_per_shard):
+          break
+
+      metrics = _remove_padding_eval(metrics, nonpaddings)
+      metrics = {k: jnp.mean(metrics[k]) for k in metrics.keys()}
+      eval_summaries[iter_name] = metrics
+
+      clu_metrics = {k: clu.metrics.Average.from_model_output(jnp.asarray([metrics[k]])) for k in metrics}
+      eval_summaries[iter_name] = mm.write_metrics_summary(  # pytype: disable=wrong-arg-types  # jax-ndarray
+        clu_metrics, train_state.step, num_steps)
+
+
+      logging.info(f'Completed eval. Metrics: {metrics}')
+    return {k: v.result() for k, v in eval_summaries.items()}
+
   def compile_eval(self, batches: Mapping[str, BatchType]) -> None:
     """Pre-compiles eval step (if not yet compiled).
 
@@ -623,6 +717,44 @@ class BaseTrainer(abc.ABC):
           cache_key]
       tock = _time()
       self.eval_metrics_managers[eval_name].write_scalar(  # pytype: disable=wrong-arg-types  # jax-ndarray
+          "timing/compilation_seconds", tock - tick, self.train_state.step)
+
+  def compile_eval_dali(self,
+                        batches: Mapping[str, BatchType],
+                        nonpadding: jnp.ndarray) -> None:
+    """For DALI datasets, pre-compiles eval step (if not yet compiled).
+
+    Not required.
+
+    Pre-compiles the evaluation step for each evaluation dataset, reusing cached
+    compilations where possible. In other words, if multiple evaluation datasets
+    have equivalent shapes/dtypes for the batch and initial metrics,
+    recompilation will be avoided.
+
+    If not called before `eval`, compilation will occur automatically on the
+    first step and JAX's "jit cache" will be used to avoid recompilation for
+    future steps.
+
+    Args:
+      batches: a mapping from evaluation dataset name to a sample batch. The
+        batch may contain dummy values, but the shapes and dtypes must be
+        correct.
+       nonpadding: a dummy boolean array of padding values.
+    """
+    for eval_name, batch in batches.items():
+      tick = time.time()
+      cache_key: BatchSpec = FrozenDict(jax.eval_shape(lambda: batch))  # pylint:disable=cell-var-from-loop
+      if cache_key not in self._compiled_eval_step_cache:
+        if jax.process_count() > 1:
+          batch = partitioning.host_local_array_to_global_array(
+              batch, self._partitioner.mesh,
+              self._partitioner.data_partition_spec)
+        self._compiled_eval_step_cache[cache_key] = self._partitioner.compile(
+            self._partitioned_score_step, self.train_state, batch, nonpadding)
+      self._compiled_eval_steps[eval_name] = self._compiled_eval_step_cache[
+          cache_key]
+      tock = time.time()
+      self.eval_metrics_managers[eval_name].write_scalar(
           "timing/compilation_seconds", tock - tick, self.train_state.step)
 
   @property
@@ -818,6 +950,10 @@ def eval_step(model: models.BaseModel, train_state: train_state_lib.TrainState,
     # pytype: enable=wrong-arg-types
   return metrics
 
+def score_step(model: models.BaseModel, train_state: train_state_lib.TrainState,
+               batch: Mapping[str, jnp.ndarray], nonpaddings: jnp.ndarray) -> MetricMapType:
+  metrics = model.get_metrics_per_batch(train_state.params, batch)
+  return metrics, nonpaddings
 
 def train_with_lr(
     train_state: train_state_lib.TrainState,
@@ -927,6 +1063,16 @@ class Trainer(BaseTrainer):
     return self._partitioner.partition(
         lambda *args, **kwargs: eval_step(self._model, *args, **kwargs),
         in_axis_resources=(self._train_state_axes,
+                           self._partitioner.data_partition_spec),
+        out_axis_resources=None)
+
+  @cached_property
+  def _partitioned_score_step(self) -> PartitionedEvalCallable:
+    return self._partitioner.partition(
+        lambda train_state, batch, nonpaddings: score_step(self._model, train_state,
+                                                           batch, nonpaddings),
+        in_axis_resources=(self._train_state_axes,
+                           self._partitioner.data_partition_spec,
                            self._partitioner.data_partition_spec),
         out_axis_resources=None)
 

--- a/t5x/utils.py
+++ b/t5x/utils.py
@@ -791,10 +791,16 @@ def get_zeros_batch_like_dataset(
     dataset: tf.data.Dataset, batch_size=None
 ) -> Mapping[str, jnp.ndarray]:
   reshape = lambda s: (batch_size,) + s[1:] if batch_size else tuple(s)
-  batch_spec = {
-      k: jax.ShapeDtypeStruct(reshape(t.shape), t.dtype.as_numpy_dtype)
-      for k, t in dataset.element_spec.items()
-  }
+  if isinstance(dataset, tf.data.Dataset):
+    batch_spec = {
+        k: jax.ShapeDtypeStruct(reshape(t.shape), t.dtype.as_numpy_dtype)
+        for k, t in dataset.element_spec.items()
+    }
+  else:
+    batch_spec = {
+        k: jax.ShapeDtypeStruct(reshape(t.shape), t.dtype)
+        for k, t in dataset.element_spec.items()
+    }
   return get_zeros_batch_like_spec(batch_spec)
 
 


### PR DESCRIPTION
This PR makes T5X compatible with the [NVIDIA Data Loading Library (DALI)](https://github.com/NVIDIA/DALI/tree/c4f105e1119ef887f037830a5551c04f9062bb74). DALI can be used to accelerate processing of image, video and audio data.