### PR TITLE
Disable golden tests in contributed gpu layers_test.py

### DIFF
--- a/t5x/contrib/gpu/t5/layers_test.py
+++ b/t5x/contrib/gpu/t5/layers_test.py
@@ -499,46 +499,46 @@ class DenseTest(parameterized.TestCase):
         ],
         dtype=np.float32)
     params = module.init(random.PRNGKey(0), inputs, deterministic=True)
-    self.assertEqual(
-        jax.tree_map(lambda a: a.tolist(), params), {
-            'params': {
-                'wi': {
-                    'kernel': [[
-                        -0.8675811290740967, 0.08417510986328125,
-                        0.022586345672607422, -0.9124102592468262
-                    ],
-                               [
-                                   -0.19464373588562012, 0.49809837341308594,
-                                   0.7808468341827393, 0.9267289638519287
-                               ]],
-                },
-                'wo': {
-                    'kernel': [[0.01154780387878418, 0.1397249698638916],
-                               [0.974980354309082, 0.5903260707855225],
-                               [-0.05997943878173828, 0.616570234298706],
-                               [0.2934272289276123, 0.8181164264678955]],
-                },
-            },
-            'params_axes': {
-                'wi': {
-                    'kernel_axes': AxisMetadata(names=('embed', 'mlp')),
-                },
-                'wo': {
-                    'kernel_axes': AxisMetadata(names=('mlp', 'embed')),
-                },
-            },
-        })
+    # self.assertEqual(
+    #     jax.tree_map(lambda a: a.tolist(), params), {
+    #         'params': {
+    #             'wi': {
+    #                 'kernel': [[
+    #                     -0.8675811290740967, 0.08417510986328125,
+    #                     0.022586345672607422, -0.9124102592468262
+    #                 ],
+    #                            [
+    #                                -0.19464373588562012, 0.49809837341308594,
+    #                                0.7808468341827393, 0.9267289638519287
+    #                            ]],
+    #             },
+    #             'wo': {
+    #                 'kernel': [[0.01154780387878418, 0.1397249698638916],
+    #                            [0.974980354309082, 0.5903260707855225],
+    #                            [-0.05997943878173828, 0.616570234298706],
+    #                            [0.2934272289276123, 0.8181164264678955]],
+    #             },
+    #         },
+    #         'params_axes': {
+    #             'wi': {
+    #                 'kernel_axes': AxisMetadata(names=('embed', 'mlp')),
+    #             },
+    #             'wo': {
+    #                 'kernel_axes': AxisMetadata(names=('mlp', 'embed')),
+    #             },
+    #         },
+    #     })
     result = module.apply(params, inputs, deterministic=True)
-    np.testing.assert_allclose(
-        result.tolist(),
-        [[[0.5237172245979309, 0.8508185744285583],
-          [0.5237172245979309, 0.8508185744285583],
-          [1.2344461679458618, 2.3844780921936035]],
-         [[1.0474344491958618, 1.7016371488571167],
-          [0.6809444427490234, 0.9663378596305847],
-          [1.0474344491958618, 1.7016371488571167]]],
-        rtol=1e-6,
-    )
+    # np.testing.assert_allclose(
+    #     result.tolist(),
+    #     [[[0.5237172245979309, 0.8508185744285583],
+    #       [0.5237172245979309, 0.8508185744285583],
+    #       [1.2344461679458618, 2.3844780921936035]],
+    #      [[1.0474344491958618, 1.7016371488571167],
+    #       [0.6809444427490234, 0.9663378596305847],
+    #       [1.0474344491958618, 1.7016371488571167]]],
+    #     rtol=1e-6,
+    # )
 
 
 class RelativePositionBiasesTest(absltest.TestCase):
@@ -580,10 +580,10 @@ class RelativePositionBiasesTest(absltest.TestCase):
         random.PRNGKey(0), self.query_len, self.key_len, bidirectional=True)
     self.assertEqual(outputs.shape,
                      (1, self.num_heads, self.query_len, self.key_len))
-    self.assertAlmostEqual(outputs[0, 0, 0, 0], 0.55764728, places=5)
-    self.assertAlmostEqual(outputs[0, 1, 2, 1], -0.10935841, places=5)
-    self.assertAlmostEqual(outputs[0, 1, 4, 6], 0.14510104, places=5)
-    self.assertAlmostEqual(outputs[0, 2, 4, 6], -0.36783996, places=5)
+    # self.assertAlmostEqual(outputs[0, 0, 0, 0], 0.55764728, places=5)
+    # self.assertAlmostEqual(outputs[0, 1, 2, 1], -0.10935841, places=5)
+    # self.assertAlmostEqual(outputs[0, 1, 4, 6], 0.14510104, places=5)
+    # self.assertAlmostEqual(outputs[0, 2, 4, 6], -0.36783996, places=5)
 
   def test_relative_attention_unidirectional_params(self):
     """Tests that unidirectional relative position biases have expected params."""
@@ -610,10 +610,10 @@ class RelativePositionBiasesTest(absltest.TestCase):
         random.PRNGKey(0), self.query_len, self.key_len, bidirectional=False)
     self.assertEqual(outputs.shape,
                      (1, self.num_heads, self.query_len, self.key_len))
-    self.assertAlmostEqual(outputs[0, 0, 0, 0], 0.55764728, places=5)
-    self.assertAlmostEqual(outputs[0, 1, 2, 1], -0.10935841, places=5)
-    self.assertAlmostEqual(outputs[0, 1, 4, 6], -0.13101986, places=5)
-    self.assertAlmostEqual(outputs[0, 2, 4, 6], 0.39296466, places=5)
+    # self.assertAlmostEqual(outputs[0, 0, 0, 0], 0.55764728, places=5)
+    # self.assertAlmostEqual(outputs[0, 1, 2, 1], -0.10935841, places=5)
+    # self.assertAlmostEqual(outputs[0, 1, 4, 6], -0.13101986, places=5)
+    # self.assertAlmostEqual(outputs[0, 2, 4, 6], 0.39296466, places=5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We've disabled an old flax RNG compat mode, so we're disabling some forked golden tests in layers_test.py to unbreak head (corresponding to an internal change in the original layers just landed.)