### PR TITLE
[NVIDIA] Fix default output features

### DIFF
--- a/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config/dummy_wikipedia_seqio.py
+++ b/t5x/contrib/gpu/scripts_gpu/dummy_wikipedia_config/dummy_wikipedia_seqio.py
@@ -22,10 +22,16 @@ TaskRegistry = seqio.TaskRegistry
 
 DEFAULT_OUTPUT_FEATURES = {
     "inputs": seqio.Feature(
-        vocabulary=t5.data.get_default_vocabulary(), add_eos=True,
+        vocabulary=seqio.SentencePieceVocabulary(
+            sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model",
+        ),
+        add_eos=True,
         required=False),
     "targets": seqio.Feature(
-        vocabulary=t5.data.get_default_vocabulary(), add_eos=True)
+        vocabulary=seqio.SentencePieceVocabulary(
+            sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model",
+        ),
+        add_eos=True)
 }
 
 # ================================ Wikipedia ===================================

--- a/t5x/contrib/gpu/scripts_gpu/seqio_tasks.py
+++ b/t5x/contrib/gpu/scripts_gpu/seqio_tasks.py
@@ -34,11 +34,20 @@ TaskRegistry = seqio.TaskRegistry
 
 DEFAULT_OUTPUT_FEATURES = {
     "inputs":
-        seqio.Feature(vocabulary=t5.data.get_default_vocabulary(),
-                      add_eos=True,
-                      required=False),
+        seqio.Feature(
+            vocabulary=seqio.SentencePieceVocabulary(
+                sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model",
+            ),
+            add_eos=True,
+            required=False
+        ),
     "targets":
-        seqio.Feature(vocabulary=t5.data.get_default_vocabulary(), add_eos=True)
+        seqio.Feature(
+            vocabulary=seqio.SentencePieceVocabulary(
+                sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model",
+            ),
+            add_eos=True
+        )
 }
 
 # ================================== The Pile ====================================


### PR DESCRIPTION
The definition of equality was changed for SentencePiece models (see [this commit](https://github.com/google/seqio/commit/14cbb0c3ac688222b713857152af118d0b414636)), which is causing vocab mismatch failures. This PR updates the default data vocabulary to exactly match that of the model config.